### PR TITLE
Create common authentication method for all components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env/
 app/__pycache__/
 misc/figs/~$estimates-per-milestone.xlsx
+nginx/config/htpasswd.admin

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,8 +2,10 @@ FROM python:3.8-slim-buster
 WORKDIR /usr/src/app
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_RUN_PORT=5000
 #Server will reload itself on file changes if in dev mode
-ENV FLASK_ENV=development
+ENV FLASK_DEBUG=True
+# ENV FLASK_ENV=development
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,7 @@
 from flask import Flask
+
 app = Flask(__name__)
-@app.route('/')
+
+@app.route('/flask')
 def home():
     return 'Flask with docker!'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,11 @@ services:
       - ./jupyterlab/jupyter_server_config.py:/home/jovyan/.jupyter/jupyter_server_config.py
 
   webapp:
-    build: app/
+    build:
+      context: ./app/
+    hostname: webapp
+    ports:
+      - 5000:5000
     networks:
       internal:
         aliases:
@@ -49,6 +53,8 @@ services:
           - webserver
     volumes:
       - ./nginx/config/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/config/htpasswd.admin:/etc/nginx/htpasswd.admin
+      # - ./nginx/config:/etc/nginx/conf.d
       - ./nginx/static:/data/www
     depends_on:
       - dsnb

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,6 +3,20 @@
 This assumes that LoNG has already been [installed](installation.md).
 
 
+## Create a user
+
+
+
+```
+htpasswd -c ./nginx/config/htpasswd.admin admin
+```
+
+You will be asked to enter your password twice.
+
+<-- Check what happens if you run this command twice -->
+<-- Instructions for resetting your password -->
+<-- What happens if you start LoNG without a password file? -->
+
 ## Launching LoNG
 
 Open your shell and navigate to the directory you installed LoNG in. Then run this command:

--- a/nginx/config/nginx.conf
+++ b/nginx/config/nginx.conf
@@ -32,12 +32,40 @@ http {
     upstream jupyterlab {
        server dsnb:8888;
     }
+    upstream flask {
+       server webapp:5000;
+    }
     server {
         listen 80;
         location / {
+            try_files $uri $uri/ =404;
             root /data/www;
+            auth_basic "Restricted Content";
+            auth_basic_user_file /etc/nginx/htpasswd.admin;
+        }
+        location /flask {
+            auth_basic "Restricted Content";
+            auth_basic_user_file /etc/nginx/htpasswd.admin;
+            proxy_http_version 1.1;
+            proxy_pass_request_headers on;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Accept-Encoding "";
+
+            proxy_pass http://flask;
+            # proxy_redirect default;
         }
         location /jupyter  {
+            auth_basic "Restricted Content";
+            auth_basic_user_file /etc/nginx/htpasswd.admin;
+            proxy_http_version 1.1;
+            proxy_pass_request_headers on;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Accept-Encoding "";
+
             proxy_pass http://jupyterlab;
         }
     }


### PR DESCRIPTION
This is to enable a sufficient authentication barrier to enable a user to host LoNG locally on their own laptop.

- [x] Add Nginx Basic Authentication
- [ ] Add instructions for creating the initial password.
- [ ] Add automatic authentication between nginx and jupyter 
- [ ] Update contributing docs
- [ ] (optional) Add firewall / client restrictions